### PR TITLE
feat(hero): add workshop registration CTA beside event register

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -72,6 +72,12 @@ export default function Hero() {
               </button>
             </motion.a>
 
+            <motion.a href="/workshop" target="_blank" variants={buttonVariants}>
+              <button className="text-md relative z-50 w-full cursor-pointer rounded-full bg-[#90EAF2] px-4 py-2 font-bold text-primary-black transition-shadow hover:shadow-lg md:text-lg 2xl:px-8 2xl:py-4 2xl:text-2xl">
+                Register For Workshop
+              </button>
+            </motion.a>
+
             {/* <motion.a href="/speakers" variants={buttonVariants}>
               <button className="text-md relative z-50 w-full cursor-pointer rounded-full bg-[#ECC89D] px-4 py-2 font-bold text-primary-black transition-shadow hover:shadow-lg md:text-lg 2xl:px-8 2xl:py-4 2xl:text-2xl">
                 See All Speakers


### PR DESCRIPTION
Place a Register For Workshop button next to Register To Attend, linking to /workshop so attendees can grab the Meetumo workshop signup in one click.